### PR TITLE
ipv6 additions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,6 +12,7 @@ check_rbl depends on several Perl modules:
  * Monitoring::Plugin::Getopt
  * Monitoring::Plugin::Threshold
  * Net::DNS
+ * Net::IP
  * Readonly
 
 Perl modules can be found on the "Comprehensive Perl Archive Network"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ my %prereqs = (
     'Data::Validate::IP'     => 0,
     'English'                => 0,
     'Net::DNS'               => 0,
+    'Net::IP '               => 0,
     'Readonly'               => 0,
     'IO::Select'             => 0,
 );

--- a/check_rbl
+++ b/check_rbl
@@ -28,6 +28,7 @@ use Data::Validate::Domain qw(is_hostname);
 use Data::Validate::IP qw(is_ipv4 is_ipv6);
 use IO::Select;
 use Net::DNS;
+use Net::IP qw(ip_expand_address);
 use Readonly;
 use English qw(-no_match_vars);
 
@@ -389,6 +390,10 @@ sub validate {
 
     }
 
+    if(is_ipv6($ip)){
+	    $ip = Net::IP::ip_expand_address($ip,6);
+    }
+
     return $ip;
 
 }
@@ -516,8 +521,15 @@ sub run {
     # build address lists
     my @addrs;
     foreach my $server (@servers) {
-        ( my $local_ip = $ip ) =~
-s/(\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3})/$4.$3.$2.$1.$server/mxs;
+	my $local_ip = $ip;
+	if(is_ipv6($local_ip)) {	
+		$local_ip = reverse $local_ip;
+		$local_ip =~ s/://g;
+		$local_ip =~ s/(.)/$1\./g;
+       		$local_ip = $local_ip.$server;
+	} else {
+       		$local_ip  =~ s/(\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3})/$4.$3.$2.$1.$server/mxs;
+	}
         push @addrs, $local_ip;
     }
 
@@ -538,6 +550,7 @@ s/(\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3})/$4.$3.$2.$1.$server/mxs;
             }
 
             # extract RBL we checked
+            $addr =~ s/^(?:[a-f0-9][.]){32}//mxs;
             $addr =~ s/^(?:\d+[.]){4}//mxs;
             if ( defined $host ) {
                 if ( $host eq q{} ) {


### PR DESCRIPTION
Allow legacy IPv6 address queries per #9. If IP is v6 format, the query will expand out the v6 IP, reverse it, and prefix it to the server name.