### PR TITLE
Added append string possibility

### DIFF
--- a/check_rbl
+++ b/check_rbl
@@ -20,7 +20,7 @@ package main;
 use strict;
 use warnings;
 
-our $VERSION = '1.4.3';
+our $VERSION = '1.4.4';
 
 use Data::Validate::Domain qw(is_hostname);
 use Data::Validate::IP qw(is_ipv4 is_ipv6);
@@ -77,6 +77,7 @@ Readonly our $DEFAULT_TIMEOUT       => 15;
 Readonly our $DEFAULT_RETRIES       => 4;
 Readonly our $DEFAULT_WORKERS       => 20;
 Readonly our $DEFAULT_QUERY_TIMEOUT => 15;
+Readonly our $DEFAULT_APPEND_STRING => '';
 
 # IMPORTANT: Nagios plugins could be executed using embedded perl in this case
 #            the main routine would be executed as a subroutine and all the
@@ -484,6 +485,13 @@ sub run {
         default  => $DEFAULT_QUERY_TIMEOUT,
     );
 
+    $options->arg(
+        spec     => 'append|a=s',
+        help     => 'Append string at the end of the plugin output',
+        required => 0,
+        default  => $DEFAULT_APPEND_STRING,
+    );
+
     $options->getopts();
 
     ###############
@@ -575,6 +583,7 @@ s/(\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3})/$4.$3.$2.$1.$server/mxs;
     my $total = scalar @listed;
 
     my $status;
+    my $appendstring = $options->append;
     if ( $options->get('whitelistings') ) {
 
         $status =
@@ -618,6 +627,11 @@ s/(\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3}) [.] (\d{1,3})/$4.$3.$2.$1.$server/mxs;
         value => time - $time,
         uom   => q{s},
     );
+
+    # append string defined in append argument to status output
+    if ( $appendstring ne '' ) {
+      $status .= " $appendstring";
+    }
 
     $plugin->nagios_exit( $threshold->get_status($total), $status );
 


### PR DESCRIPTION
This PR adds a new optional argument "append" (-a) to the plugin.
It allows to add a string at the end of the output. We created this for a customer who wanted a link to a DNSBL Search engine at the end of the plugin. But of course the append string can be anything.

Example:

```
./check_rbl -H 8.8.8.8 -s bl.spamcop.net -a "(check out more here: Online DNSBL Search)"
CHECK_RBL OK - 8.8.8.8 BLACKLISTED on 0 servers of 1 (check out more here: Online DNSBL Search) | servers=0;0;0 time=0s;;
```

I took the liberty of increasing the plugin's version with this PR. If you have another roadmap or version numbering in mind, please adjust.