### PR TITLE
RIP bl.spamcannibal.org

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -86,7 +86,6 @@ server=spamlist.or.kr
 server=t3direct.dnsbl.net.au
 server=ubl.lashback.com
 server=all.s5h.net
-server=bl.spamcannibal.org
 server=dnsbl.anticaptcha.net
 server=dnsbl.dronebl.org
 server=dnsbl.spfbl.net


### PR DESCRIPTION
The domain spamcannibal.org expired at the end of May 2019. DNSBL is no longer working.