### PR TITLE
RIP emailbasura.org

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -60,7 +60,6 @@ server=zen.spamhaus.org
 server=zombie.dnsbl.sorbs.net
 server=blackholes.five-ten-sg.com
 server=blacklist.woody.ch
-server=bl.emailbasura.org
 server=bogons.cymru.com
 server=combined.abuse.ch
 server=duinv.aupads.org


### PR DESCRIPTION
RIP emailbasura.org. 
Domain obviously expired and is now up for auction (as of Oct 30th 2019)
Also see https://www.claudiokuenzler.com/blog/907/blacklisted-on-bl.emailbasura.org-another-dnsbl-gone