### PR TITLE
Remove dynip.rothen.com (seems dead)

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -61,7 +61,6 @@ server=blacklist.woody.ch
 server=bogons.cymru.com
 server=combined.abuse.ch
 server=duinv.aupads.org
-server=dynip.rothen.com
 server=ohps.dnsbl.net.au
 server=omrs.dnsbl.net.au
 server=orvedb.aupads.org


### PR DESCRIPTION
dynip.rothen.com is dead since this morning

![image](https://user-images.githubusercontent.com/3702203/94699041-32312480-033a-11eb-93ce-56c5d48ca37a.png)
