### PR TITLE
Remove dnsbl.anticaptcha.net (dead)

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -81,7 +81,6 @@ server=spamlist.or.kr
 server=t3direct.dnsbl.net.au
 server=ubl.lashback.com
 server=all.s5h.net
-server=dnsbl.anticaptcha.net
 server=dnsbl.dronebl.org
 server=dnsbl.spfbl.net
 server=ips.backscatterer.org


### PR DESCRIPTION
Just visit https://www.anticaptcha.net/ and you're greeted with a greatly designed domain sale page.