### PR TITLE
Add possibility to use a specific DNS resolver

### DIFF
--- a/check_rbl
+++ b/check_rbl
@@ -12,6 +12,7 @@ package main;
 # Copyright (c) 2009-2021 Matteo Corti <matteo@corti.li>
 # Copyright (c) 2009 ETH Zurich.
 # Copyright (c) 2010 Elan Ruusamae <glen@delfi.ee>.
+# Copyright (c) 2022 Claudio Kuenzler <ck@claudiokuenzler.com>.
 #
 # This module is free software; you can redistribute it and/or modify it
 # under the terms of GNU general public license (gpl) version 3.
@@ -20,7 +21,7 @@ package main;
 use strict;
 use warnings;
 
-our $VERSION = '1.6.4';
+our $VERSION = '1.6.5';
 
 use Data::Validate::Domain qw(is_hostname);
 use Data::Validate::IP qw(is_ipv4 is_ipv6);
@@ -140,6 +141,12 @@ sub init_dns_resolver {
         $res->retry($retries);
     }
 
+    if (defined $options->nameserver) {
+        $res->nameservers( $options->nameserver );
+    }
+
+    my @nameservers = $res->nameservers();
+    debug("Using DNS Resolver: @nameservers");
     return $res;
 }
 
@@ -466,6 +473,12 @@ sub run {
         help     => 'Append string at the end of the plugin output',
         required => 0,
         default  => $DEFAULT_APPEND_STRING,
+    );
+
+    $options->arg(
+        spec     => 'nameserver|n=s',
+        help     => 'Use this nameserver IP as DNS resolver (only one IP supported)',
+        required => 0,
     );
 
     $options->getopts();


### PR DESCRIPTION
This PR adds the possibility to specify a DNS resolver to do the RBL/DNSBL lookups (`-n / --nameserver`). 
Without this option, the system's nameservers are used (usually defined /etc/resolv.conf). 

Why is this important? Because Spamhaus has deployed a new policy that DNS lookups coming from public resolvers (such as Google's 8.8.8.8 or Cloudflare's 1.1.1.1) are not served anymore. Instead a DNS record (127.255.255.254) is shown as response. check_rbl then believes this means the requested host is blacklisted:

```
# /usr/lib/nagios/plugins/check_rbl -H 212.103.71.210 -s zen.spamhaus.org
CHECK_RBL CRITICAL - 212.103.71.210 BLACKLISTED on 1 server of 1 (zen.spamhaus.org (127.255.255.254)) | servers=1;0;0 time=0s;;
```

By specifying a DNS nameserver, the plugin will use this given nameserver as resolver instead:

```
# ./check_rbl -H 212.103.71.210 -s zen.spamhaus.org -n 208.67.222.222
CHECK_RBL OK - 212.103.71.210 BLACKLISTED on 0 servers of 1 | servers=0;0;0 time=0s;;
```

See also https://www.claudiokuenzler.com/blog/1231/postfix-reject-mails-blocked-using-zen-spamhaus-dnsbl-open-resolver for additional information.