### PR TITLE
Remove ips.backscatterer.org

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -66,7 +66,6 @@ server=http.dnsbl.sorbs.net
 server=images.rbl.msrbl.net
 server=ip4.bl.zenrbl.pl
 server=iprbl.mailcleaner.net
-server=ips.backscatterer.org
 server=ips.whitelisted.org
 server=ix.dnsbl.manitu.net
 server=korea.services.net


### PR DESCRIPTION
Looks like ips.backscatterer.org is not a reliable RBL anymore or has stopped working. 
Getting irrelevant and wrong DNS records as reply.

```
Additional Info: CHECK_RBL WARNING - xxx.xxx.xxx.xxx (smtp.example.com) BLACKLISTED on 1 server of 89 (ips.backscatterer.org (62.0.58.94)) 
```