### PR TITLE
Fix typos and conflicting -a option

### DIFF
--- a/check_rbl
+++ b/check_rbl
@@ -507,7 +507,7 @@ sub run {
     );
 
     $options->arg(
-        spec     => 'authoritative|a',
+        spec     => 'authoritative|A',
         help     => 'Always use the corresponding authoritative name server',
         required => 0,
     );
@@ -531,10 +531,10 @@ sub run {
 
     if (   defined $options
         && defined $options->authoritative
-        && defined $options->namneserver )
+        && defined $options->nameserver )
     {
         $plugin->nagios_exit( Monitoring::Plugin->UNKNOWN,
-'--or authoritaive and --nameserver cannot be specified at the same time'
+'--or authoritative and --nameserver cannot be specified at the same time'
         );
     }
 


### PR DESCRIPTION
-a was used for --append and --authoritative, the latter is changed to -A.

Using the --authoritative option also caused an error because of a typo for the nameserver option.