### PR TITLE
spec file extension for being able to be built on Fedora/Copr

### DIFF
--- a/check_rbl.spec
+++ b/check_rbl.spec
@@ -1,5 +1,5 @@
 %define version          1.7.2
-%define release          0
+%define release          1
 %define sourcename       check_rbl
 %define packagename      nagios-plugins-check-rbl
 %define nagiospluginsdir %{_libdir}/nagios/plugins
@@ -21,6 +21,8 @@ Source:    https://github.com/matteocorti/check_rbl/releases/download/v%{version
 
 # Fedora build requirement (not needed for EPEL{4,5})
 BuildRequires: perl(ExtUtils::MakeMaker)
+# Fedora build requirement (EPEL >=8, Fedora >= 38)
+BuildRequires: perl(FindBin)
 
 Requires: perl-Module-Install perl-Readonly perl-Monitoring-Plugin perl-Test-Simple perl-Perl-Critic rpm-build perl-Net-DNS perl-Net-IP perl-Data-Validate-IP perl-App-cpanminus perl-Capture-Tiny
 
@@ -54,6 +56,9 @@ rm -rf %{buildroot}
 %{_mandir}/man1/%{sourcename}.1*
 
 %changelog
+* Wed Dec 28 2023 Matteo Corti <matteo@corti.li> - 1.7.2-1
+- Add BuildReq perl(FindBin) for EPEL >= 9 and Fedora >= 38
+
 * Thu Jun 29 2023 Matteo Corti <matteo@corti.li> - 1.7.2-0
 - Update to 1.7.2
 

--- a/check_rbl.spec
+++ b/check_rbl.spec
@@ -25,6 +25,7 @@ BuildRequires: perl(ExtUtils::MakeMaker)
 BuildRequires: perl(FindBin) make
 
 Requires: perl-Module-Install perl-Readonly perl-Monitoring-Plugin perl-Test-Simple perl-Perl-Critic rpm-build perl-Net-DNS perl-Net-IP perl-Data-Validate-IP perl-App-cpanminus perl-Capture-Tiny
+Requires: perl(Data::Validate::Domain)
 
 %description
 check_rbl is a Nagios plugin to check if an SMTP server is blacklisted
@@ -57,7 +58,8 @@ rm -rf %{buildroot}
 
 %changelog
 * Wed Dec 28 2023 Matteo Corti <matteo@corti.li> - 1.7.2-1
-- Add BuildReq for EPEL >= 9 and Fedora >= 38: perl(FindBin) make
+- Add BuildRequirement for EPEL >= 9 and Fedora >= 38: perl(FindBin) make
+- Add Requirement perl(Data::Validate::Domain)
 
 * Thu Jun 29 2023 Matteo Corti <matteo@corti.li> - 1.7.2-0
 - Update to 1.7.2

--- a/check_rbl.spec
+++ b/check_rbl.spec
@@ -21,8 +21,8 @@ Source:    https://github.com/matteocorti/check_rbl/releases/download/v%{version
 
 # Fedora build requirement (not needed for EPEL{4,5})
 BuildRequires: perl(ExtUtils::MakeMaker)
-# Fedora build requirement (EPEL >=8, Fedora >= 38)
-BuildRequires: perl(FindBin)
+# Fedora build requirement (EPEL >=9, Fedora >= 38)
+BuildRequires: perl(FindBin) make
 
 Requires: perl-Module-Install perl-Readonly perl-Monitoring-Plugin perl-Test-Simple perl-Perl-Critic rpm-build perl-Net-DNS perl-Net-IP perl-Data-Validate-IP perl-App-cpanminus perl-Capture-Tiny
 
@@ -57,7 +57,7 @@ rm -rf %{buildroot}
 
 %changelog
 * Wed Dec 28 2023 Matteo Corti <matteo@corti.li> - 1.7.2-1
-- Add BuildReq perl(FindBin) for EPEL >= 9 and Fedora >= 38
+- Add BuildReq for EPEL >= 9 and Fedora >= 38: perl(FindBin) make
 
 * Thu Jun 29 2023 Matteo Corti <matteo@corti.li> - 1.7.2-0
 - Update to 1.7.2

--- a/check_rbl.spec
+++ b/check_rbl.spec
@@ -57,7 +57,7 @@ rm -rf %{buildroot}
 %{_mandir}/man1/%{sourcename}.1*
 
 %changelog
-* Wed Dec 28 2023 Matteo Corti <matteo@corti.li> - 1.7.2-1
+* Thu Dec 28 2023 Peter Bieringer <pb@bieringer.de> - 1.7.2-1
 - Add BuildRequirement for EPEL >= 9 and Fedora >= 38: perl(FindBin) make
 - Add Requirement perl(Data::Validate::Domain)
 


### PR DESCRIPTION
minor extension is required for working build on Copr for EPEL>=9 and Fedora>=38

See successful builds:
https://copr.fedorainfracloud.org/coprs/pbiering/InternetServerExtensions/build/6823613/

Required `perl-Data-Validate-Domain` module was successfully rebuilded from Fedora rawhide for EPEL9:
https://copr.fedorainfracloud.org/coprs/pbiering/InternetServerExtensions/build/6823613/

Filed also ticket to get this included https://bugzilla.redhat.com/show_bug.cgi?id=2256089