### PR TITLE
Remove spamtrap.drbl.drand.net

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -137,7 +137,6 @@ server=spamguard.leadmon.net
 server=spamlist.or.kr
 server=spamrbl.imp.ch
 server=spamsources.fabel.dk
-server=spamtrap.drbl.drand.net
 server=swl.spamhaus.org
 server=tor.dan.me.uk
 server=torexit.dan.me.uk


### PR DESCRIPTION
spamtrap.drbl.drand.net has gone offline since March 26th 2024. The plugin therefore falsely reported all mail servers checked against this DNSBL as listed.