### PR TITLE
Bye bye rbl.lugh.ch

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -89,7 +89,6 @@ server=rbl.blockedservers.com
 server=rbl.inter.net
 server=rbl.interserver.net
 server=rbl.ircbl.org
-server=rbl.lugh.ch
 server=rbl.metunet.com
 server=rbl.rbldns.ru
 server=rbl.schulte.org


### PR DESCRIPTION
From https://lugh.ch/pages/dnsbl.html:

>  THIS SERVICE IS GONE
> Ensure that you remove rbl.lugh.ch from your infrastructure as it returns 127.0.0.2 (listed) responses starting from 2024-07-22

![image](https://github.com/user-attachments/assets/b06ea323-a2ec-4543-b62b-61ab5df633c4)
