### PR TITLE
Remove spam.dnsbl.anonmails.de

### DIFF
--- a/check_rbl.ini
+++ b/check_rbl.ini
@@ -103,7 +103,6 @@ server=sbl.spamhaus.org
 server=score.spfbl.net
 server=singular.ttk.pte.hu
 server=spam.abuse.ch
-server=spam.dnsbl.anonmails.de
 server=spam.pedantic.org
 server=spam.rbl.blockedservers.com
 server=spam.rbl.msrbl.net


### PR DESCRIPTION
Since yesterday evening (November 12th 2024) this DNSBL does not exist anymore or gives bogus responses.

```
CHECK_RBL WARNING - xxx.xxx.xxx.xxx (example.com) BLACKLISTED on 1 server of 80 (spam.dnsbl.anonmails.de (146.112.61.108))
```
